### PR TITLE
remove peer id check also performed in addPeer method

### DIFF
--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
@@ -419,9 +419,7 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
             Peer p = Peer.deserialize(pexPeer.toByteArray());
             Log.d(TAG, "From " + peer + " | found peer in pexList: " + p);
 
-            if (!getPeerHandler().hashId.equals(p.getPeerId())) {
-                getPeerHandler().getOrMakePeer(p.getPeerId(), p.getAddress());
-            }
+            getPeerHandler().getOrMakePeer(p.getPeerId(), p.getAddress());
         }
     }
 


### PR DESCRIPTION
Removes an if statement that checks for duplicate peer names.
Adding the peer is still stopped in getOrMakePeer for peers in the list and in addPeer for checking against your own name, but these at least give the right errors.
A first step towards #18