### PR TITLE
47 51 update overlay ui

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "nl.tudelft.cs4160.trustchain_android"
         minSdkVersion 21
         targetSdkVersion 26
-        versionCode 14
-        versionName "0.304"
+        versionCode 15
+        versionName "0.305"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "nl.tudelft.cs4160.trustchain_android"
         minSdkVersion 21
         targetSdkVersion 26
-        versionCode 15
-        versionName "0.305"
+        versionCode 16
+        versionName "0.306"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/Block/TrustChainBlockTest.java
+++ b/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/Block/TrustChainBlockTest.java
@@ -9,13 +9,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.libsodium.jni.NaCl;
-import org.libsodium.jni.encoders.Hex;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import nl.tudelft.cs4160.trustchain_android.block.TrustChainBlockHelper;
-import nl.tudelft.cs4160.trustchain_android.block.ValidationResult;
 import nl.tudelft.cs4160.trustchain_android.crypto.DualSecret;
 import nl.tudelft.cs4160.trustchain_android.crypto.Key;
 import nl.tudelft.cs4160.trustchain_android.main.OverviewConnectionsActivity;

--- a/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/inbox/InboxItemTest.java
+++ b/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/inbox/InboxItemTest.java
@@ -15,8 +15,8 @@ import java.util.Arrays;
 import nl.tudelft.cs4160.trustchain_android.crypto.DualSecret;
 import nl.tudelft.cs4160.trustchain_android.crypto.Key;
 import nl.tudelft.cs4160.trustchain_android.crypto.PublicKeyPair;
-import nl.tudelft.cs4160.trustchain_android.peer.Peer;
 import nl.tudelft.cs4160.trustchain_android.main.UserConfigurationActivity;
+import nl.tudelft.cs4160.trustchain_android.peer.Peer;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;

--- a/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/main/ChainInfoTest.java
+++ b/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/main/ChainInfoTest.java
@@ -12,8 +12,6 @@ import android.view.ViewParent;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/peer/PeerHandlerTest.java
+++ b/app/src/androidTest/java/nl/tudelft/cs4160/trustchain_android/peer/PeerHandlerTest.java
@@ -1,7 +1,5 @@
 package nl.tudelft.cs4160.trustchain_android.peer;
 
-import junit.framework.TestCase;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +11,6 @@ import java.util.List;
 import nl.tudelft.cs4160.trustchain_android.crypto.Key;
 import nl.tudelft.cs4160.trustchain_android.crypto.PublicKeyPair;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerActivity.java
@@ -10,14 +10,11 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.GridLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
-
-import com.google.protobuf.ByteString;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +26,6 @@ import nl.tudelft.cs4160.trustchain_android.crypto.PublicKeyPair;
 import nl.tudelft.cs4160.trustchain_android.message.MessageProto;
 import nl.tudelft.cs4160.trustchain_android.storage.database.TrustChainDBHelper;
 import nl.tudelft.cs4160.trustchain_android.storage.sharedpreferences.UserNameStorage;
-import nl.tudelft.cs4160.trustchain_android.util.ByteArrayConverter;
 
 import static android.view.Gravity.CENTER;
 

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
@@ -1,16 +1,8 @@
 package nl.tudelft.cs4160.trustchain_android.chainExplorer;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.net.Uri;
-import android.os.Build;
-import android.support.design.widget.Snackbar;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,25 +12,17 @@ import android.widget.Toast;
 
 import com.google.protobuf.ByteString;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
 import nl.tudelft.cs4160.trustchain_android.R;
 import nl.tudelft.cs4160.trustchain_android.block.TrustChainBlockHelper;
-import nl.tudelft.cs4160.trustchain_android.block.ValidationResult;
 import nl.tudelft.cs4160.trustchain_android.crypto.PublicKeyPair;
 import nl.tudelft.cs4160.trustchain_android.message.MessageProto;
-import nl.tudelft.cs4160.trustchain_android.storage.database.TrustChainDBHelper;
 import nl.tudelft.cs4160.trustchain_android.storage.sharedpreferences.UserNameStorage;
 import nl.tudelft.cs4160.trustchain_android.util.ByteArrayConverter;
 import nl.tudelft.cs4160.trustchain_android.util.OpenFileClickListener;
-import nl.tudelft.cs4160.trustchain_android.util.Util;
 
 public class ChainExplorerAdapter extends BaseAdapter {
     static final String TAG = "ChainExplorerAdapter";

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/ConnectionExplanationActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/ConnectionExplanationActivity.java
@@ -14,7 +14,7 @@ public class ConnectionExplanationActivity extends AppCompatActivity {
 
     private ArrayList<String> symbolList;
     private String[] explanationText;
-    private int[] colorList = {R.color.colorStatusConnected, R.color.colorStatusConnecting, R.color.colorStatusCantConnect, R.color.colorReceived, R.color.colorSent, 0, 0};
+    private int[] colorList = {R.color.colorStatusConnected, R.color.colorStatusConnecting, R.color.colorStatusCantConnect, android.R.color.secondary_text_light, android.R.color.secondary_text_light};
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,19 +50,14 @@ public class ConnectionExplanationActivity extends AppCompatActivity {
      * Create the list of symbols for the list view.
      */
     private void createSymbolList() {
-        symbolList = new ArrayList<String>();
+        symbolList = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             String symbol = this.getString(R.string.circle_symbol);
             symbolList.add(symbol);
         }
 
-        for (int i = 0; i < 2; i++) {
-            String symbol = this.getString(R.string.indicator_symbol);
-            symbolList.add(symbol);
-        }
-
-        symbolList.add(getString(R.string.last_received));
-        symbolList.add(getString(R.string.last_sent));
+        symbolList.add(getString(R.string.last_received,""));
+        symbolList.add(getString(R.string.last_sent,""));
     }
 
     /**
@@ -73,8 +68,6 @@ public class ConnectionExplanationActivity extends AppCompatActivity {
         ids.add(R.string.connected);
         ids.add(R.string.connecting);
         ids.add(R.string.cannot_connect);
-        ids.add(R.string.received_packet);
-        ids.add(R.string.sent_packet);
         ids.add(R.string.time_since_received);
         ids.add(R.string.time_since_sent);
 

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
@@ -49,17 +49,17 @@ import nl.tudelft.cs4160.trustchain_android.inbox.InboxActivity;
 import nl.tudelft.cs4160.trustchain_android.message.MessageProto;
 import nl.tudelft.cs4160.trustchain_android.network.Network;
 import nl.tudelft.cs4160.trustchain_android.network.NetworkStatusListener;
+import nl.tudelft.cs4160.trustchain_android.passport.ocr.camera.CameraActivity;
 import nl.tudelft.cs4160.trustchain_android.peer.Peer;
 import nl.tudelft.cs4160.trustchain_android.peer.PeerHandler;
 import nl.tudelft.cs4160.trustchain_android.peer.PeerListener;
-import nl.tudelft.cs4160.trustchain_android.passport.ocr.camera.CameraActivity;
 import nl.tudelft.cs4160.trustchain_android.storage.database.TrustChainDBHelper;
 import nl.tudelft.cs4160.trustchain_android.storage.sharedpreferences.BootstrapIPStorage;
 import nl.tudelft.cs4160.trustchain_android.storage.sharedpreferences.SharedPreferencesStorage;
 import nl.tudelft.cs4160.trustchain_android.storage.sharedpreferences.UserNameStorage;
 import nl.tudelft.cs4160.trustchain_android.util.RequestCode;
 
-import static nl.tudelft.cs4160.trustchain_android.main.UserConfigurationActivity.*;
+import static nl.tudelft.cs4160.trustchain_android.main.UserConfigurationActivity.VERSION_NAME_KEY;
 
 public class OverviewConnectionsActivity extends AppCompatActivity implements NetworkStatusListener, PeerListener {
 
@@ -130,7 +130,7 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
         network = Network.getInstance(getApplicationContext());
         network.getMessageHandler().setPeerHandler(getPeerHandler());
         network.setNetworkStatusListener(this);
-        network.updateConnectionType((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+        updateConnectionType(network.getConnectionTypeString((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE)));
     }
 
     /**
@@ -352,7 +352,7 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
             while(true) {
                 try {
                     // update connection type and internal ip address
-                    network.updateConnectionType((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+                    updateConnectionType(network.getConnectionTypeString((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE)));
                     network.showLocalIpAddress();
                     if (peerHandler.size() > 0) {
                         // select 10 random peers to send an introduction request to
@@ -497,14 +497,13 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
     /**
      * Display connectionType
      *
-     * @param connectionType
-     * @param typename
-     * @param subtypename
+     * @param connectionTypeStr String representation of the connection type
      */
     @Override
-    public void updateConnectionType(int connectionType, String typename, String subtypename) {
-        String connectionTypeStr = typename + " " + subtypename;
-        ((TextView) findViewById(R.id.connection_type)).setText(connectionTypeStr);
+    public void updateConnectionType(String connectionTypeStr) {
+        runOnUiThread( () ->{
+            ((TextView) findViewById(R.id.connection_type)).setText(connectionTypeStr);
+        });
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
@@ -98,7 +98,8 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
             while(true) {
                 updatePeerLists();
                 try {
-                    Thread.sleep(500);
+                    // update every 198 ms, because we want to display a sent/received message cue when a message was received less than 200ms ago.
+                    Thread.sleep(198);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -346,6 +347,9 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
 
             while(true) {
                 try {
+                    // update connection type and internal ip address
+                    network.updateConnectionType((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+                    network.showLocalIpAddress();
                     if (peerHandler.size() > 0) {
                         // select 10 random peers to send an introduction request to
                         int limit = 10;
@@ -428,8 +432,8 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
 
         if (peerHandler.getWanVote().vote(socketAddress)) {
             wan = peerHandler.getWanVote().getAddress().toString();
+            setWanvote(wan.replace("/",""));
         }
-        setWanvote(wan.replace("/",""));
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
@@ -73,6 +73,8 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
     private TrustChainDBHelper dbHelper;
     private Network network;
     private PeerHandler peerHandler;
+    private TextView activePeersText;
+    private TextView newPeersText;
     private String wan = "";
     private static final String TAG = "OverviewConnections";
 
@@ -143,6 +145,8 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
             e.printStackTrace();
         }
         ((TextView )findViewById(R.id.version)).setText(getString(R.string.version, versionName));
+        activePeersText = findViewById(R.id.active_peers_text);
+        newPeersText = findViewById(R.id.new_peers_text);
     }
 
     /**
@@ -463,6 +467,8 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
                     peerHandler.splitPeerList();
                     activePeersAdapter.notifyDataSetChanged();
                     newPeersAdapter.notifyDataSetChanged();
+                    activePeersText.setText(getString(R.string.left_connections_with_count,peerHandler.getactivePeersList().size()));
+                    newPeersText.setText(getString(R.string.right_connections_with_count,peerHandler.getnewPeersList().size()));
                 }
             }
         });

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/PeerListAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/PeerListAdapter.java
@@ -1,9 +1,12 @@
 package nl.tudelft.cs4160.trustchain_android.main;
 
+import android.animation.ArgbEvaluator;
+import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,8 +37,6 @@ public class PeerListAdapter extends ArrayAdapter<Peer> {
         TextView mLastReceived;
         TextView mDestinationAddress;
         TextView mStatusIndicator;
-        TextView mReceivedIndicator;
-        TextView mSentIndicator;
         TableLayout mTableLayoutConnection;
     }
 
@@ -60,8 +61,6 @@ public class PeerListAdapter extends ArrayAdapter<Peer> {
             holder.mLastSent = convertView.findViewById(R.id.last_sent);
             holder.mLastReceived = convertView.findViewById(R.id.last_received);
             holder.mDestinationAddress = convertView.findViewById(R.id.destination_address);
-            holder.mReceivedIndicator = convertView.findViewById(R.id.received_indicator);
-            holder.mSentIndicator = convertView.findViewById(R.id.sent_indicator);
             holder.mTableLayoutConnection = convertView.findViewById(R.id.tableLayoutConnection);
             convertView.setTag(holder);
         } else {
@@ -103,25 +102,39 @@ public class PeerListAdapter extends ArrayAdapter<Peer> {
             holder.mDestinationAddress.setText(String.format("%s:%d", peer.getIpAddress().toString().substring(1), peer.getPort()));
         }
 
-        if (System.currentTimeMillis() - peer.getLastSentTime() < 200) {
-            animate(holder.mSentIndicator);
-        }
         if (System.currentTimeMillis() - peer.getLastReceivedTime() < 200) {
-            animate(holder.mReceivedIndicator);
+            animate(holder.mLastReceived, context.getResources().getColor(R.color.colorReceived));
         }
+
+        if (System.currentTimeMillis() - peer.getLastSentTime() < 200) {
+            animate(holder.mLastSent, context.getResources().getColor(R.color.colorSent));
+
+        }
+
         setOnClickListener(holder.mTableLayoutConnection, position);
 
         if(peer.isReceivedFrom()) {
-            holder.mLastReceived.setText(Util.timeToString(System.currentTimeMillis() - peer.getLastReceivedTime()));
+            holder.mLastReceived.setText(context.getString(R.string.last_received,
+                    Util.timeToString(System.currentTimeMillis() - peer.getLastReceivedTime())));
         }
-        holder.mLastSent.setText(Util.timeToString(System.currentTimeMillis() - peer.getLastSentTime()));
+        holder.mLastSent.setText(context.getString(R.string.last_sent,
+                Util.timeToString(System.currentTimeMillis() - peer.getLastSentTime())));
 
         return convertView;
     }
 
-    private void animate(final View view) {
-        view.setAlpha(1);
-        view.animate().alpha(0).setDuration(500).start();
+    /**
+     * Animate the textview so it changes color for 500ms
+     * @param view The textview that will change color
+     * @param toColor The color that it will change to
+     */
+    private void animate(final TextView view, int toColor) {
+        ObjectAnimator colorAnim = ObjectAnimator.ofInt(view, "textColor",
+            toColor,
+            context.getResources().getColor(android.R.color.secondary_text_light));
+        colorAnim.setDuration(500);
+        colorAnim.setEvaluator(new ArgbEvaluator());
+        colorAnim.start();
     }
 
     private String connectionTypeString(int connectionType) {
@@ -163,6 +176,10 @@ public class PeerListAdapter extends ArrayAdapter<Peer> {
                     InboxItemStorage.addInboxItem(context, i);
                     Snackbar mySnackbar = Snackbar.make(coordinatorLayout,
                             context.getString(R.string.snackbar_peer_added,peer.getName()), Snackbar.LENGTH_SHORT);
+                    // set max lines so long peer names will still display properly
+                    TextView snackbarTextView = mySnackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+                    snackbarTextView.setMaxLines(1);
+                    snackbarTextView.setEllipsize(TextUtils.TruncateAt.MIDDLE);
                     mySnackbar.show();
                 } else {
                     Snackbar mySnackbar = Snackbar.make(coordinatorLayout,

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/Network.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/Network.java
@@ -313,15 +313,12 @@ public class Network {
         channel.send(outputBuffer.wrap(message.toByteArray()), peer.getAddress());
         Log.d(TAG, "Sending " + message);
         peer.sentData();
-        if (networkStatusListener != null) {
-            networkStatusListener.updatePeerLists();
-        }
     }
 
     /**
      * Show local ip address.
      */
-    private void showLocalIpAddress() {
+    public void showLocalIpAddress() {
         ShowLocalIPTask showLocalIPTask = new ShowLocalIPTask();
         showLocalIPTask.execute();
     }
@@ -358,7 +355,6 @@ public class Network {
                 peer.receivedData();
                 PubKeyAndAddressPairStorage.addPubkeyAndAddressPair(context, sourcePubKey, address);
                 handleMessage(peer, message, sourcePubKey, context);
-                networkStatusListener.updatePeerLists();
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/Network.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/Network.java
@@ -142,22 +142,20 @@ public class Network {
     }
 
     /**
-     * Request and display the current connection type.
+     * Request and return the current connection type.
+     * @return a string representation of the current connection type
      */
-    public void updateConnectionType(ConnectivityManager cm) {
+    public String getConnectionTypeString(ConnectivityManager cm) {
+        String typename = "No connection";
+        String subtypeName = "";
         try {
-            cm.getActiveNetworkInfo().getType();
-        } catch (Exception e) {
-            return;
-        }
+            connectionType = cm.getActiveNetworkInfo().getType();
+            typename = cm.getActiveNetworkInfo().getTypeName();
+            subtypeName = cm.getActiveNetworkInfo().getSubtypeName();
+        } catch(Exception e) {
 
-        connectionType = cm.getActiveNetworkInfo().getType();
-        String typename = cm.getActiveNetworkInfo().getTypeName();
-        String subtypeName = cm.getActiveNetworkInfo().getSubtypeName();
-
-        if (networkStatusListener != null) {
-            networkStatusListener.updateConnectionType(connectionType, typename, subtypeName);
         }
+        return typename + " " + subtypeName;
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/NetworkStatusListener.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/network/NetworkStatusListener.java
@@ -9,6 +9,6 @@ public interface NetworkStatusListener {
     void updateInternalSourceAddress(String address);
     void updatePeerLists();
     void updateWan(MessageProto.Message message) throws UnknownHostException;
-    void updateConnectionType(int connectionType, String typename, String subtypename);
+    void updateConnectionType(String connectionTypeStr);
     PeerHandler getPeerHandler();
 }

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/nfc/PassportConActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/nfc/PassportConActivity.java
@@ -24,7 +24,6 @@ import org.jmrtd.PassportService;
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.security.Security;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -33,7 +32,6 @@ import nl.tudelft.cs4160.trustchain_android.passport.DocumentData;
 import nl.tudelft.cs4160.trustchain_android.passport.PassportHolder;
 import nl.tudelft.cs4160.trustchain_android.passport.ocr.ManualInputActivity;
 import nl.tudelft.cs4160.trustchain_android.util.ByteArrayConverter;
-import nl.tudelft.cs4160.trustchain_android.util.Util;
 
 public class PassportConActivity extends AppCompatActivity {
 

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/ManualInputActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/ManualInputActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/camera/CameraActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/camera/CameraActivity.java
@@ -16,14 +16,11 @@ package nl.tudelft.cs4160.trustchain_android.passport.ocr.camera;/*
 
 
 import android.app.Activity;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
 import nl.tudelft.cs4160.trustchain_android.R;
-import nl.tudelft.cs4160.trustchain_android.passport.nfc.PassportConActivity;
 
-import static nl.tudelft.cs4160.trustchain_android.passport.ocr.camera.CameraFragment.GET_DOC_INFO;
 import static nl.tudelft.cs4160.trustchain_android.passport.ocr.camera.CameraFragment.REQUEST_WRITE_CAMERA_PERMISSIONS;
 
 public class CameraActivity extends Activity {

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/camera/CameraFragment.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/passport/ocr/camera/CameraFragment.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Fragment;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/MutualBlockAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/MutualBlockAdapter.java
@@ -1,7 +1,6 @@
 package nl.tudelft.cs4160.trustchain_android.peersummary;
 
 import android.content.Context;
-
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.support.v7.widget.RecyclerView;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/PeerSummaryActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/PeerSummaryActivity.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.ConnectivityManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/PeerSummaryActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/peersummary/PeerSummaryActivity.java
@@ -165,7 +165,6 @@ public class PeerSummaryActivity extends AppCompatActivity implements CrawlReque
     public void requestChain() {
         network = Network.getInstance(getApplicationContext());
         network.setMutualBlockListener(this);
-        network.updateConnectionType((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
 
         int sq = -5;
         MessageProto.TrustChainBlock block = dbHelper.getBlock(inboxItemOtherPeer.getPeer().getPublicKeyPair().toBytes(), dbHelper.getMaxSeqNum(inboxItemOtherPeer.getPeer().getPublicKeyPair().toBytes()));
@@ -181,15 +180,12 @@ public class PeerSummaryActivity extends AppCompatActivity implements CrawlReque
                         .setRequestedSequenceNumber(sq)
                         .setLimit(100).build();
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Log.d("BCrawlTest", "Sent crawl request");
-                    network.sendCrawlRequest(inboxItemOtherPeer.getPeer(), crawlRequest);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+        new Thread(() -> {
+            try {
+                Log.d("BCrawlTest", "Sent crawl request");
+                network.sendCrawlRequest(inboxItemOtherPeer.getPeer(), crawlRequest);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }).start();
     }

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/util/Util.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/util/Util.java
@@ -141,7 +141,7 @@ public class Util {
     public static String timeToString(long msSinceLastMessage) {
         // display seconds
         if(msSinceLastMessage < 60000) {
-            return " " + ((int) Math.floor(msSinceLastMessage / 1000.0)) + "s";
+            return ((int) Math.floor(msSinceLastMessage / 1000.0)) + "s";
         }
 
         // display minutes
@@ -149,7 +149,7 @@ public class Util {
             int seconds = ((int) Math.floor((msSinceLastMessage / 1000.0)));
             int minutes = ((int) Math.floor(seconds /60.0));
             seconds = seconds % 60;
-            return " " + minutes + "m" + seconds + "s";
+            return minutes + "m" + seconds + "s";
         }
 
         // display hours
@@ -157,7 +157,7 @@ public class Util {
             int minutes = ((int) Math.floor(msSinceLastMessage /60000.0));
             int hours = ((int) Math.floor(minutes / 60.0));
             minutes = minutes % 60;
-            return " " + hours + "h" + minutes + "m";
+            return hours + "h" + minutes + "m";
         }
 
         // default: more than 1 day, display nothing, getting a time since last message that is this

--- a/app/src/main/res/layout/activity_overview_connections.xml
+++ b/app/src/main/res/layout/activity_overview_connections.xml
@@ -70,12 +70,14 @@
 
             <TableRow android:layout_marginBottom="10dp">
                 <TextView
+                    android:id="@+id/active_peers_text"
                     android:layout_weight="1"
                     android:text="@string/left_connections"
                     android:textColor="@android:color/black"
                     android:textStyle="bold" />
 
                 <TextView
+                    android:id="@+id/new_peers_text"
                     android:layout_weight="1"
                     android:text="@string/right_connections"
                     android:textColor="@android:color/black"

--- a/app/src/main/res/layout/activity_overview_connections.xml
+++ b/app/src/main/res/layout/activity_overview_connections.xml
@@ -49,6 +49,8 @@
                     android:text="@string/peer_id" />
 
                 <TextView
+                    android:ellipsize="middle"
+                    android:singleLine="true"
                     android:id="@+id/peer_id"
                     android:layout_weight="1"
                     android:text="" />

--- a/app/src/main/res/layout/content_detail.xml
+++ b/app/src/main/res/layout/content_detail.xml
@@ -51,6 +51,8 @@
 
             <TextView
                 android:id="@+id/peer_id"
+                android:ellipsize="middle"
+                android:singleLine="true"
                 android:layout_weight="1"
                 android:text="" />
 

--- a/app/src/main/res/layout/item_connection_explanation_list.xml
+++ b/app/src/main/res/layout/item_connection_explanation_list.xml
@@ -7,15 +7,16 @@
     <TableLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="0.15">
+        android:layout_weight="0.20">
 
         <TextView
             android:id="@+id/colorSymbol"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:text="@string/circle_symbol"
+            android:layout_marginStart="5dp"
             android:textAlignment="center"
+            android:ellipsize="middle"
+            android:singleLine="true"
             android:textColor="@color/colorAccent"
             android:textSize="20sp" />
 
@@ -25,17 +26,8 @@
         android:id="@+id/symbolExplanation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="0.85">
+        android:layout_weight="0.80">
 
-        <TextView
-            android:id="@+id/meaningText"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:hint="@string/symbolMeaningText"
-            android:textColor="@android:color/black"
-            android:textStyle="bold" />
-.
         <TextView
             android:id="@+id/symbolMeaning"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/item_peer_connection_list.xml
+++ b/app/src/main/res/layout/item_peer_connection_list.xml
@@ -1,75 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="horizontal">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="10dp">
 
     <TableLayout
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.15">
+        android:id="@+id/tableLayoutConnection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-        <TableRow>
+        <TableRow
+            android:layout_height="wrap_content">
 
             <TextView
                 android:id="@+id/status_indicator"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/circle_symbol"
-                android:layout_marginLeft="10dp"
-                android:textAlignment="center"
+                android:layout_weight="2"
                 android:textColor="@color/colorAccent"
                 android:textSize="20sp"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_marginTop="-8sp">
-
-            <TextView
-                android:id="@+id/received_indicator"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.5"
-                android:alpha="0"
-                android:text="@string/indicator_symbol"
-                android:textColor="@color/colorReceived"
-                android:textSize="15sp"/>
-
-            <TextView
-                android:id="@+id/sent_indicator"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.5"
-                android:alpha="0"
-                android:text="@string/indicator_symbol"
-                android:textColor="@color/colorSent"
-                android:textSize="15sp"/>
-        </TableRow>
-
-
-    </TableLayout>
-
-    <TableLayout
-        android:id="@+id/tableLayoutConnection"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.85">
-
-        <TableRow
-            android:layout_height="wrap_content">
-
             <TextView
                 android:id="@+id/peer_id"
                 android:hint="@string/peer_id"
+                android:ellipsize="middle"
+                android:singleLine="true"
                 android:layout_width="0dp"
-                android:layout_weight="1"
+                android:layout_weight="24"
                 android:textStyle="bold"
                 android:textColor="@android:color/black"/>
             <TextView
                 android:id="@+id/connection"
                 android:hint="@string/connection"
                 android:layout_width="0dp"
-                android:layout_weight="1"
+                android:layout_weight="24"
                 android:textColor="@android:color/secondary_text_light"/>
 
         </TableRow>
@@ -88,31 +53,23 @@
         </TableRow>
 
         <TableRow
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
             <TextView
-                android:text="@string/last_received"
-                android:textColor="@android:color/secondary_text_light" />
-
-            <TextView
                 android:id="@+id/last_received"
+                android:hint="@string/last_received_hint"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:textColor="@android:color/secondary_text_light" />
 
             <TextView
-                android:text="@string/last_sent"
-                android:textColor="@android:color/secondary_text_light" />
-
-            <TextView
                 android:id="@+id/last_sent"
+                android:hint="@string/last_sent_hint"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:textColor="@android:color/secondary_text_light"/>
 
         </TableRow>
-
     </TableLayout>
-
 </LinearLayout>

--- a/app/src/main/res/values-w320dp/strings.xml
+++ b/app/src/main/res/values-w320dp/strings.xml
@@ -1,4 +1,6 @@
 <resources>
-    <string name="last_received">R: </string>
-    <string name="last_sent">S: </string>
+    <string name="last_received">Recv: %s</string>
+    <string name="last_sent">Sent: %s</string>
+    <string name="last_received_hint">Recv:</string>
+    <string name="last_sent_hint">Sent: </string>
 </resources>

--- a/app/src/main/res/values-w480dp/strings.xml
+++ b/app/src/main/res/values-w480dp/strings.xml
@@ -1,4 +1,6 @@
 <resources>
-    <string name="last_received">Recv: </string>
-    <string name="last_sent">Sent: </string>
+    <string name="last_received">Recv: %s</string>
+    <string name="last_sent">Sent: %s</string>
+    <string name="last_received_hint">Recv:</string>
+    <string name="last_sent_hint">Sent: </string>
 </resources>

--- a/app/src/main/res/values-w600dp/strings.xml
+++ b/app/src/main/res/values-w600dp/strings.xml
@@ -1,4 +1,6 @@
 <resources>
-    <string name="last_received">Received: </string>
-    <string name="last_sent">Sent: </string>
+    <string name="last_received">Received: %s</string>
+    <string name="last_sent">Sent: %s</string>
+    <string name="last_received_hint">Received:</string>
+    <string name="last_sent_hint">Sent: </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,8 +13,10 @@
     <string name="connect">connect</string>
     <string name="view_chain">View Chain</string>
     <string name="reset_database_button">Clear Database (closes app)</string>
-    <string name="last_received">Received: </string>
-    <string name="last_sent">Sent: </string>
+    <string name="last_received">Received: %s</string>
+    <string name="last_sent">Sent: %s</string>
+    <string name="last_received_hint">Received:</string>
+    <string name="last_sent_hint">Sent: </string>
     <string name="peer_id">peer id</string>
     <string name="snackbar_peer_added">%s added to inbox</string>
     <string name="snackbar_no_pub_key">This peer didn\'t send a public key yet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <string name="outgoing">outgoing</string>
     <string name="left_connections">Active Peers</string>
     <string name="right_connections">New Peers</string>
+    <string name="left_connections_with_count">Active Peers (%d)</string>
+    <string name="right_connections_with_count">New Peers (%d)</string>
     <string name="connection">Connection</string>
     <string name="connectable_ratio">Connectable\nratio</string>
     <string name="connectable_peers">Connectable\nPeers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,15 +98,15 @@
 
     <!-- Connection explanation view -->
     <string name="symbolMeaningText">Meaning:</string>
-    <string name="connectionInfoText">Here we provide an explanation of each symbol and their corresponding color.</string>
+    <string name="connectionInfoText">Explanations of texts and symbols of the connection overview.</string>
     <string name="symbolExplanationText">Explanation</string>
     <string name="connected">Connected with peer</string>
     <string name="connecting">Connecting with peer</string>
     <string name="cannot_connect">Cannot connect with peer</string>
     <string name="received_packet">Received a packet from peer</string>
     <string name="sent_packet">Sent a packet to peer</string>
-    <string name="time_since_received">Time since last received message"</string>
-    <string name="time_since_sent">Time since last message sent</string>
+    <string name="time_since_received">Time since last received message, lights up on message received"</string>
+    <string name="time_since_sent">Time since last sent message, lights up on message sent</string>
 
     <!--- info chain explorer -->
     <string name="color_info">Color is based on the hash of the public key.</string>

--- a/app/src/test/java/nl/tudelft/cs4160/trustchain_android/main/PeerListAdapterTest.java
+++ b/app/src/test/java/nl/tudelft/cs4160/trustchain_android/main/PeerListAdapterTest.java
@@ -33,70 +33,70 @@ public class PeerListAdapterTest {
     @Test
     public void timeToStringTestSeconds1() {
         long time = 1000;
-        String expected = " 1s";
+        String expected = "1s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringTestSeconds2() {
         long time = 2000;
-        String expected = " 2s";
+        String expected = "2s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringTestSeconds3() {
         long time = 0;
-        String expected = " 0s";
+        String expected = "0s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringTestHours1() {
         long time = 3600000;
-        String expected = " 1h0m";
+        String expected = "1h0m";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringTestHours2() {
         long time = 3800000;
-        String expected = " 1h3m";
+        String expected = "1h3m";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringTestHours3() {
         long time = 3599999;
-        String expected = " 59m59s";
+        String expected = "59m59s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringMinutes1() {
         long time = 200000;
-        String expected = " 3m20s";
+        String expected = "3m20s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringMinutes2() {
         long time = 60000;
-        String expected = " 1m0s";
+        String expected = "1m0s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringMinutes3() {
         long time = 60001;
-        String expected = " 1m0s";
+        String expected = "1m0s";
         assertEquals(expected, Util.timeToString(time));
     }
 
     @Test
     public void timeToStringMinutes4() {
         long time = 59999;
-        String expected = " 59s";
+        String expected = "59s";
         assertEquals(expected, Util.timeToString(time));
     }
 


### PR DESCRIPTION
- overlay is now updated 5 times a second instead of 2 times a second and on each received/sent message, so it should be faster with many connected peers now.
- removed indicator bars for sending/receiving messages, instead the timers change color on received/sent messages
- removed S. and R. as smallest strings for sent and received. Sent and Recv are now the smallest. (more space was available since the bars were removed)
- added counters for total active/new peers
- long peer id's now get ellipsized in overviewconnections

closes #47 and closes #51 